### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish:
     name: Publish to Maven Central
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/2](https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/2)

To fix this problem, add a `permissions` key to the job or to the root of the workflow, specifying least-privilege permissions required for the workflow to operate. For publishing to Maven Central, fetching contents (e.g., checkout) requires `contents: read`. There are no steps that write to the repository or GitHub resources. Therefore, set `contents: read` at either the root level or job level; since there is only one job, the job level is conventional. This change should be made in `.github/workflows/publish.yml`, at the same indentation as other job-level keys (e.g., before or after `runs-on`). No new methods, imports, or other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
