### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI - Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/1](https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/1)

To fix the problem, add a `permissions: { contents: read }` block at the workflow level — that is, directly below the workflow `name` (line 1). This ensures all jobs default to the least privilege necessary to run, unless overridden at the job level. This grant allows the jobs to read repository contents (checkout code), but disables actions such as pushing, modifying pull requests, etc., via the GITHUB_TOKEN. If any specific job requires additional permissions, further blocks can be added at the job-level, but for this workflow, only read access is required. No other changes or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to include a top-level permissions setting granting read access to repository contents.
  * Workflow structure and job execution remain unchanged; builds and tests continue to run as before.
  * No impact on application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->