### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/4](https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow file (`.github/workflows/publish.yml`). As a starting point, set `contents: read` at the root level, which restricts most GitHub token access to the minimal required permission. If any step or job specifically requires additional permissions (e.g., writing to issues or pull requests), those can be elevated accordingly at the job level. This change should be placed just after the workflow name and prior to the `on:` block, or else within specific jobs. For this workflow, adding it to the root is preferred for simplicity.

Implementation steps:
- Edit `.github/workflows/publish.yml`.
- Add a `permissions:` block at the top level, e.g. after `name: Release`.
- Set minimal required permissions: typically, `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
