### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,4 +1,6 @@
 name: Publish Snapshot
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/5](https://github.com/FalkorDB/jena-falkordb-adapter/security/code-scanning/5)

To address the issue, explicitly declare the minimum necessary `permissions` at the top level of the workflow file, OR within the specific job if appropriate. In this case, the job doesn't seem to require any write-level token permission to the repository: It only reads code and uses secrets to deploy to an external repo, so `contents: read` suffices. Add the following block immediately after the workflow `name:` and before the `on:` block for clarity. Alternatively, placing it within the job is correct, but a top-level block covers everything and is more concise for single-job workflows.

You should add:

```yaml
permissions:
  contents: read
```

right after the `name: Publish Snapshot` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
